### PR TITLE
Fix #32. Issue number ignored

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "delete-comment",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "description": "delete comments from issue/pr by username",
   "main": "lib/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,21 +8,22 @@ async function run(): Promise<void> {
   try {
     const token: string = core.getInput('github_token')
     const userName: string = core.getInput('delete_user_name')
-    const issueNumber: string = core.getInput('issue_number')
+    const issueNumber: number = parseInt(core.getInput('issue_number'))
 
     const octokit = github.getOctokit(token)
 
-    const issues = []
+    const issues: number[] = []
 
     if (issueNumber) {
       issues.push(issueNumber)
     } else {
-      const allIssues = await octokit.paginate(
+      const allIssues: number[] = await octokit.paginate(
         'GET /repos/:owner/:repo/issues?state=all',
         {
           owner: github.context.repo.owner,
           repo: github.context.repo.repo
-        }
+        },
+        response => response.data.map(issue => issue.issue_number)
       )
 
       issues.push(...allIssues)
@@ -32,7 +33,7 @@ async function run(): Promise<void> {
       const resp = await octokit.issues.listComments({
         owner: github.context.repo.owner,
         repo: github.context.repo.repo,
-        issue_number: (issue as any)['number']
+        issue_number: issue
       })
 
       const comments = resp.data.filter(it => it.user?.login === userName)

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,16 +17,15 @@ async function run(): Promise<void> {
     if (issueNumber) {
       issues.push(issueNumber)
     } else {
-      const allIssues: number[] = await octokit.paginate(
+      const allIssues = await octokit.paginate(
         'GET /repos/:owner/:repo/issues?state=all',
         {
           owner: github.context.repo.owner,
           repo: github.context.repo.repo
-        },
-        response => response.data.map(issue => issue.issue_number)
+        }
       )
 
-      issues.push(...allIssues)
+      issues.push(...allIssues.map((value: any) => value['number']))
     }
 
     for (const issue of issues) {


### PR DESCRIPTION
The `listComments` function needs an issue number but the `issues` arrays could contain an Issue object or a number. This modification ensures the `issues` arrays only contain numbers.